### PR TITLE
MainViewController -> ImageGeneratorViewController로 변경 및 뷰 분리

### DIFF
--- a/ImageMaker.xcodeproj/project.pbxproj
+++ b/ImageMaker.xcodeproj/project.pbxproj
@@ -20,9 +20,10 @@
 		AC2FD1BC2A7582B4006A57A0 /* KarloResponseData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2FD1A72A757F52006A57A0 /* KarloResponseData.swift */; };
 		AC2FD1BD2A7582B9006A57A0 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC2FD1A52A756B83006A57A0 /* APIKey.plist */; };
 		AC2FD1C02A758E94006A57A0 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2FD1BF2A758E94006A57A0 /* DetailViewController.swift */; };
+		AC50B4222A85B505000410C6 /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC50B4212A85B505000410C6 /* PromptView.swift */; };
 		AC542FB72A750DC0007A9AAE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FB62A750DC0007A9AAE /* AppDelegate.swift */; };
 		AC542FB92A750DC0007A9AAE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FB82A750DC0007A9AAE /* SceneDelegate.swift */; };
-		AC542FBB2A750DC0007A9AAE /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FBA2A750DC0007A9AAE /* MainViewController.swift */; };
+		AC542FBB2A750DC0007A9AAE /* ImageGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FBA2A750DC0007A9AAE /* ImageGeneratorViewController.swift */; };
 		AC542FC02A750DC1007A9AAE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AC542FBF2A750DC1007A9AAE /* Assets.xcassets */; };
 		AC542FC32A750DC1007A9AAE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AC542FC12A750DC1007A9AAE /* LaunchScreen.storyboard */; };
 		AC542FCD2A751171007A9AAE /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = AC542FCC2A751171007A9AAE /* SnapKit */; };
@@ -49,10 +50,11 @@
 		AC2FD1A92A758214006A57A0 /* KarloServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KarloServiceTests.swift; sourceTree = "<group>"; };
 		AC2FD1B02A75823D006A57A0 /* ImageMakerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ImageMakerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC2FD1BF2A758E94006A57A0 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		AC50B4212A85B505000410C6 /* PromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptView.swift; sourceTree = "<group>"; };
 		AC542FB32A750DC0007A9AAE /* ImageMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ImageMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC542FB62A750DC0007A9AAE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AC542FB82A750DC0007A9AAE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		AC542FBA2A750DC0007A9AAE /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		AC542FBA2A750DC0007A9AAE /* ImageGeneratorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGeneratorViewController.swift; sourceTree = "<group>"; };
 		AC542FBF2A750DC1007A9AAE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AC542FC22A750DC1007A9AAE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		AC542FC42A750DC1007A9AAE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -77,12 +79,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		AC2FD1992A7561D5006A57A0 /* MainScene */ = {
+		AC2FD1992A7561D5006A57A0 /* ImageGenerationScene */ = {
 			isa = PBXGroup;
 			children = (
-				AC542FBA2A750DC0007A9AAE /* MainViewController.swift */,
+				AC50B4202A85B4F5000410C6 /* View */,
+				AC542FBA2A750DC0007A9AAE /* ImageGeneratorViewController.swift */,
 			);
-			path = MainScene;
+			path = ImageGenerationScene;
 			sourceTree = "<group>";
 		};
 		AC2FD19A2A7561E3006A57A0 /* AlbumScene */ = {
@@ -144,6 +147,14 @@
 			path = DetailScene;
 			sourceTree = "<group>";
 		};
+		AC50B4202A85B4F5000410C6 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				AC50B4212A85B505000410C6 /* PromptView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		AC542FAA2A750DC0007A9AAE = {
 			isa = PBXGroup;
 			children = (
@@ -170,7 +181,7 @@
 				AC542FB82A750DC0007A9AAE /* SceneDelegate.swift */,
 				AC2FD1A52A756B83006A57A0 /* APIKey.plist */,
 				AC2FD1A02A756676006A57A0 /* Common */,
-				AC2FD1992A7561D5006A57A0 /* MainScene */,
+				AC2FD1992A7561D5006A57A0 /* ImageGenerationScene */,
 				AC2FD19A2A7561E3006A57A0 /* AlbumScene */,
 				AC2FD1BE2A758E75006A57A0 /* DetailScene */,
 				AC542FBF2A750DC1007A9AAE /* Assets.xcassets */,
@@ -317,9 +328,10 @@
 			files = (
 				AC2FD1A22A75667E006A57A0 /* Constant.swift in Sources */,
 				AC2FD1A82A757F52006A57A0 /* KarloResponseData.swift in Sources */,
-				AC542FBB2A750DC0007A9AAE /* MainViewController.swift in Sources */,
+				AC542FBB2A750DC0007A9AAE /* ImageGeneratorViewController.swift in Sources */,
 				AC2FD1982A7561C1006A57A0 /* AlbumViewController.swift in Sources */,
 				AC542FB72A750DC0007A9AAE /* AppDelegate.swift in Sources */,
+				AC50B4222A85B505000410C6 /* PromptView.swift in Sources */,
 				AC2FD1962A755DE6006A57A0 /* ImageConfiguration.swift in Sources */,
 				AC542FB92A750DC0007A9AAE /* SceneDelegate.swift in Sources */,
 				AC2FD1C02A758E94006A57A0 /* DetailViewController.swift in Sources */,

--- a/ImageMaker.xcodeproj/project.pbxproj
+++ b/ImageMaker.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AC2FD1BD2A7582B9006A57A0 /* APIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC2FD1A52A756B83006A57A0 /* APIKey.plist */; };
 		AC2FD1C02A758E94006A57A0 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2FD1BF2A758E94006A57A0 /* DetailViewController.swift */; };
 		AC50B4222A85B505000410C6 /* PromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC50B4212A85B505000410C6 /* PromptView.swift */; };
+		AC50B4262A85BD5B000410C6 /* ConfigurationSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC50B4252A85BD5B000410C6 /* ConfigurationSliderView.swift */; };
 		AC542FB72A750DC0007A9AAE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FB62A750DC0007A9AAE /* AppDelegate.swift */; };
 		AC542FB92A750DC0007A9AAE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FB82A750DC0007A9AAE /* SceneDelegate.swift */; };
 		AC542FBB2A750DC0007A9AAE /* ImageGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC542FBA2A750DC0007A9AAE /* ImageGeneratorViewController.swift */; };
@@ -51,6 +52,7 @@
 		AC2FD1B02A75823D006A57A0 /* ImageMakerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ImageMakerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC2FD1BF2A758E94006A57A0 /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		AC50B4212A85B505000410C6 /* PromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptView.swift; sourceTree = "<group>"; };
+		AC50B4252A85BD5B000410C6 /* ConfigurationSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationSliderView.swift; sourceTree = "<group>"; };
 		AC542FB32A750DC0007A9AAE /* ImageMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ImageMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC542FB62A750DC0007A9AAE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AC542FB82A750DC0007A9AAE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				AC50B4212A85B505000410C6 /* PromptView.swift */,
+				AC50B4252A85BD5B000410C6 /* ConfigurationSliderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				AC542FB92A750DC0007A9AAE /* SceneDelegate.swift in Sources */,
 				AC2FD1C02A758E94006A57A0 /* DetailViewController.swift in Sources */,
 				AC2FD19F2A7562AD006A57A0 /* PhotoCollectionViewCell.swift in Sources */,
+				AC50B4262A85BD5B000410C6 /* ConfigurationSliderView.swift in Sources */,
 				AC2FD1A42A756955006A57A0 /* KarloService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
+++ b/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
@@ -170,7 +170,6 @@ private extension ImageGeneratorViewController {
     func configStackView() {
         self.entireStackView.addArrangedSubview(positivePromptView)
         self.entireStackView.addArrangedSubview(negativePromptView)
-        
         self.entireStackView.addArrangedSubview(imageQualitySliderView)
         self.entireStackView.addArrangedSubview(imageCountStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveStepsSliderView)
@@ -185,7 +184,6 @@ private extension ImageGeneratorViewController {
         
         configImageCountStackView()
         configDecoderSelectStackView()
-        
         configGenerateButton()
         
         entireStackView.snp.makeConstraints { make in
@@ -256,11 +254,14 @@ private extension ImageGeneratorViewController {
     @objc func decoderSelectButtonTapped(_ sender: UIButton) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let ddimAction = UIAlertAction(title: "decoder_ddim_v_prediction", style: .default) { _ in
-            sender.setTitle("decoder_ddim_v_prediction", for: .normal)
+        let ddim = "decoder_ddim_v_prediction"
+        let ddpm = "decoder_ddpm_v_prediction"
+        
+        let ddimAction = UIAlertAction(title: ddim, style: .default) { _ in
+            sender.setTitle(ddim, for: .normal)
         }
-        let ddpmAction = UIAlertAction(title: "decoder_ddpm_v_prediction", style: .default) { _ in
-            sender.setTitle("decoder_ddpm_v_prediction", for: .normal)
+        let ddpmAction = UIAlertAction(title: ddpm, style: .default) { _ in
+            sender.setTitle(ddpm, for: .normal)
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         

--- a/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
+++ b/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
@@ -76,94 +76,17 @@ class ImageGeneratorViewController: UIViewController {
 
     
     // MARK: - Image Noise Remove Steps Stack
-    private let noiseRemoveStepsStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveStepsLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveStepsLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: 20)
-        label.textColor = Constant.textColor
-        label.text = "Noise Remove Steps"
-        
-        return label
-    }()
-    
-    private let noiseRemoveStepsCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = Constant.textColor
-        label.text = "25"
-        
-        return label
-    }()
-    
-    private let noiseRemoveStepsSlider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 10
-        slider.maximumValue = 100
-        slider.value = 25
-        
-        return slider
-    }()
-    
+    private let noiseRemoveStepsSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Steps",
+                                                                            sliderValue: 25,
+                                                                            sliderMinValue: 10,
+                                                                            sliderMaxValue: 100,
+                                                                            decimalPlaces: 0)
     // MARK: - Image Noise Remove Scale Stack
-    private let noiseRemoveScaleStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-        
-    private let noiseRemoveScaleLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveScaleCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = Constant.textColor
-        label.text = "5.0"
-        
-        return label
-    }()
-    
-    private let noiseRemoveScaleLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: 20)
-        label.textColor = Constant.textColor
-        label.text = "Noise Remove Scale"
-        
-        return label
-    }()
-    
-    private let noiseRemoveScaleSlider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 1.0
-        slider.maximumValue = 20.0
-        slider.value = 5.0
-        
-        return slider
-    }()
+    private let noiseRemoveScaleSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Scale",
+                                                                            sliderValue: 5.0,
+                                                                            sliderMinValue: 1.0,
+                                                                            sliderMaxValue: 20.0,
+                                                                            decimalPlaces: 1)
     
     // MARK: - Decoder Select Stack
     private let decoderSelectStackView: UIStackView = {
@@ -330,8 +253,8 @@ private extension ImageGeneratorViewController {
         
         self.entireStackView.addArrangedSubview(imageQualitySliderView)
         self.entireStackView.addArrangedSubview(imageCountStackView)
-        self.entireStackView.addArrangedSubview(noiseRemoveStepsStackView)
-        self.entireStackView.addArrangedSubview(noiseRemoveScaleStackView)
+        self.entireStackView.addArrangedSubview(noiseRemoveStepsSliderView)
+        self.entireStackView.addArrangedSubview(noiseRemoveScaleSliderView)
         self.entireStackView.addArrangedSubview(decoderSelectStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveStepsByDecoderStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveScaleByDecoderStackView)
@@ -341,9 +264,6 @@ private extension ImageGeneratorViewController {
         negativePromptView.textViewDelegate = self
         
         configImageCountStackView()
-        
-        configNoiseRemoveStepsStackView()
-        configNoiseRemoveScaleStackView()
         
         configDecoderSelectStackView()
         
@@ -370,34 +290,6 @@ private extension ImageGeneratorViewController {
         imageCountStepper.addTarget(self, action: #selector(imageCountStepperValueChanged), for: .valueChanged)
     }
     
-    // MARK: - Noise Remove Steps Setting
-    func configNoiseRemoveStepsStackView() {
-        noiseRemoveStepsStackView.addArrangedSubview(noiseRemoveStepsLabelStackView)
-        noiseRemoveStepsStackView.addArrangedSubview(noiseRemoveStepsSlider)
-        
-        noiseRemoveStepsStackView.spacing = 10
-        
-        noiseRemoveStepsLabelStackView.addArrangedSubview(noiseRemoveStepsLabel)
-        noiseRemoveStepsLabelStackView.addArrangedSubview(UIView())
-        noiseRemoveStepsLabelStackView.addArrangedSubview(noiseRemoveStepsCountLabel)
-        
-        noiseRemoveStepsSlider.addTarget(self, action: #selector(noiseStepsSliderValueChanged), for: .valueChanged)
-    }
-    
-    // MARK: - Noise Remove Scale Setting
-    func configNoiseRemoveScaleStackView() {
-        noiseRemoveScaleStackView.addArrangedSubview(noiseRemoveScaleLabelStackView)
-        noiseRemoveScaleStackView.addArrangedSubview(noiseRemoveScaleSlider)
-        
-        noiseRemoveScaleStackView.spacing = 10
-        
-        noiseRemoveScaleLabelStackView.addArrangedSubview(noiseRemoveScaleLabel)
-        noiseRemoveScaleLabelStackView.addArrangedSubview(UIView())
-        noiseRemoveScaleLabelStackView.addArrangedSubview(noiseRemoveScaleCountLabel)
-        
-        noiseRemoveScaleSlider.addTarget(self, action: #selector(noiseScaleSliderValueChanged), for: .valueChanged)
-    }
-    
     // MARK: - Decoder Select Setting
     func configDecoderSelectStackView() {
         decoderSelectStackView.addArrangedSubview(decoderSelectLabel)
@@ -422,7 +314,7 @@ private extension ImageGeneratorViewController {
         noiseRemoveStepsByDecoderLabelStackView.addArrangedSubview(UIView())
         noiseRemoveStepsByDecoderLabelStackView.addArrangedSubview(noiseRemoveStepsByDecoderCountLabel)
         
-        noiseRemoveStepsByDecoderSlider.addTarget(self, action: #selector(noiseStepsByDecoderSliderValueChanged), for: .valueChanged)
+//        noiseRemoveStepsByDecoderSlider.addTarget(self, action: #selector(noiseStepsByDecoderSliderValueChanged), for: .valueChanged)
     }
     
     // MARK: - Noise Remove Scale By Decoder Setting
@@ -436,7 +328,7 @@ private extension ImageGeneratorViewController {
         noiseRemoveScaleByDecoderLabelStackView.addArrangedSubview(UIView())
         noiseRemoveScaleByDecoderLabelStackView.addArrangedSubview(noiseRemoveScaleByDecoderCountLabel)
         
-        noiseRemoveScaleByDecoderSlider.addTarget(self, action: #selector(noiseScaleByDecodeSliderValueChanged), for: .valueChanged)
+//        noiseRemoveScaleByDecoderSlider.addTarget(self, action: #selector(noiseScaleByDecodeSliderValueChanged), for: .valueChanged)
     }
     
     func configGenerateButton() {
@@ -452,32 +344,6 @@ private extension ImageGeneratorViewController {
         self.imageCountStpperCountLabel.text = "\(value)"
     }
     
-    // Slider func
-    @objc func imageQualitySliderValueChanged(_ sender: UISlider) {
-        let value = Int(sender.value)
-        self.imageQualityCountLabel.text = "\(value)"
-    }
-    
-    @objc func noiseStepsSliderValueChanged(_ sender: UISlider) {
-        let value = Int(sender.value)
-        self.noiseRemoveStepsCountLabel.text = "\(value)"
-    }
-    
-    @objc func noiseScaleSliderValueChanged(_ sender: UISlider) {
-        let value = String(format: "%.1f", sender.value)
-        self.noiseRemoveScaleCountLabel.text = "\(value)"
-    }
-    
-    @objc func noiseStepsByDecoderSliderValueChanged(_ sender: UISlider) {
-        let value = Int(sender.value)
-        self.noiseRemoveStepsByDecoderCountLabel.text = "\(value)"
-    }
-    
-    @objc func noiseScaleByDecodeSliderValueChanged(_ sender: UISlider) {
-        let value = String(format: "%.1f", sender.value)
-        self.noiseRemoveScaleByDecoderCountLabel.text = "\(value)"
-    }
-    
     // scrollView tapped
     @objc func dismissKeyboard() {
         view.endEditing(true)
@@ -488,8 +354,8 @@ private extension ImageGeneratorViewController {
                                                negetivePrompt: negativePromptView.promptText,
                                                imageQuality: Int(imageQualitySliderView.sliderValue),
                                                imageCount: Int(imageCountStpperCountLabel.text!)!,
-                                               noiseRemoveSteps: Int(noiseRemoveStepsCountLabel.text!)!,
-                                               noiseRemoveScale: Double(noiseRemoveScaleCountLabel.text!)!,
+                                               noiseRemoveSteps: Int(noiseRemoveStepsSliderView.sliderValue),
+                                               noiseRemoveScale: noiseRemoveScaleSliderView.sliderValue,
                                                decoder: decoderSelectButton.titleLabel!.text!,
                                                noiseRemoveStepsByDecoder: Int(noiseRemoveStepsByDecoderCountLabel.text!)!,
                                                noiseRemoveScaleByDecoder: Double(noiseRemoveScaleByDecoderCountLabel.text!)!)

--- a/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
+++ b/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
@@ -27,53 +27,14 @@ class ImageGeneratorViewController: UIViewController {
     }()
     
     // MARK: - Prompt Stack
-    private let positivePromptView: PromptView = .init(promptLabelString: "Positive Prompt")
-    private let negativePromptView: PromptView = .init(promptLabelString: "Negative Prompt")
+    private let positivePromptView: PromptView = .init(promptLabelText: "Positive Prompt")
+    private let negativePromptView: PromptView = .init(promptLabelText: "Negative Prompt")
     
     // MARK: - Image Quality Stack
-    private let imageQualityStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let imageQualityLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let imageQualityLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Image Quality"
-        label.textColor = Constant.textColor
-        label.font = .boldSystemFont(ofSize: 20)
-        
-        return label
-    }()
-    
-    private let imageQualityCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = Constant.textColor
-        label.text = "70"
-        
-        return label
-    }()
-    
-    private let imageQualitySlider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 1
-        slider.maximumValue = 100
-        slider.value = 70
-        
-        return slider
-    }()
+    private let imageQualitySliderView: ConfigurationSliderView = .init(targetLabelText: "ImageQuality",
+                                                                        sliderValue: 70, sliderMinValue: 1,
+                                                                        sliderMaxValue: 100,
+                                                                        decimalPlaces: 0)
     
     // MARK: - Image Count Stack
     private let imageCountStackView: UIStackView = {
@@ -367,7 +328,7 @@ private extension ImageGeneratorViewController {
         self.entireStackView.addArrangedSubview(positivePromptView)
         self.entireStackView.addArrangedSubview(negativePromptView)
         
-        self.entireStackView.addArrangedSubview(imageQualityStackView)
+        self.entireStackView.addArrangedSubview(imageQualitySliderView)
         self.entireStackView.addArrangedSubview(imageCountStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveStepsStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveScaleStackView)
@@ -379,7 +340,6 @@ private extension ImageGeneratorViewController {
         positivePromptView.textViewDelegate = self
         negativePromptView.textViewDelegate = self
         
-        configImageQualityStackView()
         configImageCountStackView()
         
         configNoiseRemoveStepsStackView()
@@ -396,20 +356,6 @@ private extension ImageGeneratorViewController {
             make.edges.equalTo(entireScrollView.snp.edges).inset(20)
             make.centerX.equalTo(entireScrollView.snp.centerX)
         }
-    }
-    
-    // MARK: - Image Quality Setting
-    func configImageQualityStackView() {
-        imageQualityStackView.addArrangedSubview(imageQualityLabelStackView)
-        imageQualityStackView.addArrangedSubview(imageQualitySlider)
-        
-        imageQualityStackView.spacing = 10
-        
-        imageQualityLabelStackView.addArrangedSubview(imageQualityLabel)
-        imageQualityLabelStackView.addArrangedSubview(UIView())
-        imageQualityLabelStackView.addArrangedSubview(imageQualityCountLabel)
-        
-        imageQualitySlider.addTarget(self, action: #selector(imageQualitySliderValueChanged), for: .valueChanged)
     }
     
     // MARK: - Image Count Setting
@@ -540,7 +486,7 @@ private extension ImageGeneratorViewController {
     @objc func generateButtonTapped() {
         let configuration = ImageConfiguration(prompt: positivePromptView.promptText,
                                                negetivePrompt: negativePromptView.promptText,
-                                               imageQuality: Int(imageQualityCountLabel.text!)!,
+                                               imageQuality: Int(imageQualitySliderView.sliderValue),
                                                imageCount: Int(imageCountStpperCountLabel.text!)!,
                                                noiseRemoveSteps: Int(noiseRemoveStepsCountLabel.text!)!,
                                                noiseRemoveScale: Double(noiseRemoveScaleCountLabel.text!)!,

--- a/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
+++ b/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
@@ -26,11 +26,9 @@ class ImageGeneratorViewController: UIViewController {
         return stackView
     }()
     
-    // MARK: - Prompt Stack
     private let positivePromptView: PromptView = .init(promptLabelText: "Positive Prompt")
     private let negativePromptView: PromptView = .init(promptLabelText: "Negative Prompt")
     
-    // MARK: - Image Quality Stack
     private let imageQualitySliderView: ConfigurationSliderView = .init(targetLabelText: "ImageQuality",
                                                                         sliderValue: 70, sliderMinValue: 1,
                                                                         sliderMaxValue: 100,
@@ -74,14 +72,12 @@ class ImageGeneratorViewController: UIViewController {
         return stepper
     }()
 
-    
-    // MARK: - Image Noise Remove Steps Stack
     private let noiseRemoveStepsSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Steps",
                                                                             sliderValue: 25,
                                                                             sliderMinValue: 10,
                                                                             sliderMaxValue: 100,
                                                                             decimalPlaces: 0)
-    // MARK: - Image Noise Remove Scale Stack
+    
     private let noiseRemoveScaleSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Scale",
                                                                             sliderValue: 5.0,
                                                                             sliderMinValue: 1.0,
@@ -117,94 +113,18 @@ class ImageGeneratorViewController: UIViewController {
     }()
     
     // MARK: - Noise Remove Steps By Decoder Stack
-    private let noiseRemoveStepsByDecoderStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveStepsByDecoderLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveStepsByDecoderLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Noise Remove Steps By Decoder"
-        label.font = .boldSystemFont(ofSize: 20)
-        label.textColor = Constant.textColor
-        
-        return label
-    }()
-    
-    private let noiseRemoveStepsByDecoderCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "50"
-        label.textColor = Constant.textColor
-        
-        return label
-    }()
-    
-    private let noiseRemoveStepsByDecoderSlider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 10
-        slider.maximumValue = 100
-        slider.value = 50
-        
-        return slider
-    }()
+    private let noiseRemoveStepsByDecoderSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Steps By Decoder",
+                                                                                     sliderValue: 50,
+                                                                                     sliderMinValue: 10,
+                                                                                     sliderMaxValue: 100,
+                                                                                     decimalPlaces: 0)
     
     // MARK: - Noise Remove Scale By Decoder Stack
-    private let noiseRemoveScaleByDecoderStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveScaleByDecoderLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let noiseRemoveScaleByDecoderCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "5.0"
-        label.textColor = Constant.textColor
-        
-        return label
-    }()
-    
-    private let noiseRemoveScaleByDecoderLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Noise Remove Scale By Decoder"
-        label.font = .boldSystemFont(ofSize: 20)
-        label.textColor = Constant.textColor
-        
-        return label
-    }()
-    
-    private let noiseRemoveScaleByDecoderSlider: UISlider = {
-        let slider = UISlider()
-        slider.minimumValue = 1.0
-        slider.maximumValue = 20.0
-        slider.value = 5.0
-        
-        return slider
-    }()
+    private let noiseRemoveScaleByDecoderSliderView: ConfigurationSliderView = .init(targetLabelText: "Noise Remove Scale By Decoder",
+                                                                                     sliderValue: 5.0,
+                                                                                     sliderMinValue: 1.0,
+                                                                                     sliderMaxValue: 20.0,
+                                                                                     decimalPlaces: 1)
     
     // MARK: - Generate Button
     private let generateButton: UIButton = {
@@ -256,19 +176,15 @@ private extension ImageGeneratorViewController {
         self.entireStackView.addArrangedSubview(noiseRemoveStepsSliderView)
         self.entireStackView.addArrangedSubview(noiseRemoveScaleSliderView)
         self.entireStackView.addArrangedSubview(decoderSelectStackView)
-        self.entireStackView.addArrangedSubview(noiseRemoveStepsByDecoderStackView)
-        self.entireStackView.addArrangedSubview(noiseRemoveScaleByDecoderStackView)
+        self.entireStackView.addArrangedSubview(noiseRemoveStepsByDecoderSliderView)
+        self.entireStackView.addArrangedSubview(noiseRemoveScaleByDecoderSliderView)
         self.entireStackView.addArrangedSubview(generateButton)
 
         positivePromptView.textViewDelegate = self
         negativePromptView.textViewDelegate = self
         
         configImageCountStackView()
-        
         configDecoderSelectStackView()
-        
-        configNoiseRemoveStepsByDecoderStackView()
-        configNoiseRemoveScaleByDecoderStackView()
         
         configGenerateButton()
         
@@ -303,34 +219,6 @@ private extension ImageGeneratorViewController {
         decoderSelectButton.addTarget(self, action: #selector(decoderSelectButtonTapped), for: .touchUpInside)
     }
     
-    // MARK: - Noise Remove Steps By Decoder Setting
-    func configNoiseRemoveStepsByDecoderStackView() {
-        noiseRemoveStepsByDecoderStackView.addArrangedSubview(noiseRemoveStepsByDecoderLabelStackView)
-        noiseRemoveStepsByDecoderStackView.addArrangedSubview(noiseRemoveStepsByDecoderSlider)
-        
-        noiseRemoveStepsByDecoderStackView.spacing = 10
-        
-        noiseRemoveStepsByDecoderLabelStackView.addArrangedSubview(noiseRemoveStepsByDecoderLabel)
-        noiseRemoveStepsByDecoderLabelStackView.addArrangedSubview(UIView())
-        noiseRemoveStepsByDecoderLabelStackView.addArrangedSubview(noiseRemoveStepsByDecoderCountLabel)
-        
-//        noiseRemoveStepsByDecoderSlider.addTarget(self, action: #selector(noiseStepsByDecoderSliderValueChanged), for: .valueChanged)
-    }
-    
-    // MARK: - Noise Remove Scale By Decoder Setting
-    func configNoiseRemoveScaleByDecoderStackView() {
-        noiseRemoveScaleByDecoderStackView.addArrangedSubview(noiseRemoveScaleByDecoderLabelStackView)
-        noiseRemoveScaleByDecoderStackView.addArrangedSubview(noiseRemoveScaleByDecoderSlider)
-        
-        noiseRemoveScaleByDecoderStackView.spacing = 10
-        
-        noiseRemoveScaleByDecoderLabelStackView.addArrangedSubview(noiseRemoveScaleByDecoderLabel)
-        noiseRemoveScaleByDecoderLabelStackView.addArrangedSubview(UIView())
-        noiseRemoveScaleByDecoderLabelStackView.addArrangedSubview(noiseRemoveScaleByDecoderCountLabel)
-        
-//        noiseRemoveScaleByDecoderSlider.addTarget(self, action: #selector(noiseScaleByDecodeSliderValueChanged), for: .valueChanged)
-    }
-    
     func configGenerateButton() {
         generateButton.addTarget(self, action: #selector(generateButtonTapped), for: .touchUpInside)
     }
@@ -357,8 +245,8 @@ private extension ImageGeneratorViewController {
                                                noiseRemoveSteps: Int(noiseRemoveStepsSliderView.sliderValue),
                                                noiseRemoveScale: noiseRemoveScaleSliderView.sliderValue,
                                                decoder: decoderSelectButton.titleLabel!.text!,
-                                               noiseRemoveStepsByDecoder: Int(noiseRemoveStepsByDecoderCountLabel.text!)!,
-                                               noiseRemoveScaleByDecoder: Double(noiseRemoveScaleByDecoderCountLabel.text!)!)
+                                               noiseRemoveStepsByDecoder: Int(noiseRemoveStepsByDecoderSliderView.sliderValue),
+                                               noiseRemoveScaleByDecoder: noiseRemoveScaleByDecoderSliderView.sliderValue)
         
         let albumController = AlbumViewController(imageConfiguration: configuration)
         let navigationController = UINavigationController(rootViewController: albumController)

--- a/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
+++ b/ImageMaker/ImageGenerationScene/ImageGeneratorViewController.swift
@@ -1,14 +1,15 @@
 //
-//  MainViewController.swift
+//  ImageGeneratorViewController.swift
 //  ImageMaker
 //
 //  Created by 이정민 on 2023/07/29.
 //
 
 import UIKit
+
 import SnapKit
 
-class MainViewController: UIViewController {
+class ImageGeneratorViewController: UIViewController {
     private let entireScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -26,99 +27,8 @@ class MainViewController: UIViewController {
     }()
     
     // MARK: - Prompt Stack
-    private let promptStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let promptLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let promptLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Prompt"
-        label.textColor = Constant.textColor
-        label.font = .boldSystemFont(ofSize: 20)
-        
-        return label
-    }()
-    
-    private let promptTextCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "0 / 256"
-        label.textColor = .lightGray
-        label.font = .preferredFont(forTextStyle: .caption2)
-        
-        return label
-    }()
-    
-    private let promptTextView: UITextView = {
-        let textView = UITextView()
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.layer.cornerRadius = 8.0
-        textView.layer.borderWidth = 1.0
-        textView.layer.borderColor = UIColor.lightGray.cgColor
-        
-        return textView
-    }()
-    
-    // MARK: - Negative Prompt Stack
-    
-    private let negativePromptStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
-    
-    private let negativePromptLabelStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        
-        return stackView
-    }()
-    
-    private let negativePromptLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "Negative prompt"
-        label.textColor = Constant.textColor
-        label.font = .boldSystemFont(ofSize: 20)
-        
-        return label
-    }()
-    
-    private let negativePromptTextCountLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "0 / 256"
-        label.textColor = .lightGray
-        label.font = .preferredFont(forTextStyle: .caption2)
-        
-        return label
-    }()
-    
-    private let negativePromptTextView: UITextView = {
-        let textView = UITextView()
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.layer.cornerRadius = 8.0
-        textView.layer.borderWidth = 1.0
-        textView.layer.borderColor = UIColor.lightGray.cgColor
-        
-        return textView
-    }()
+    private let positivePromptView: PromptView = .init(promptLabelString: "Positive Prompt")
+    private let negativePromptView: PromptView = .init(promptLabelString: "Negative Prompt")
     
     // MARK: - Image Quality Stack
     private let imageQualityStackView: UIStackView = {
@@ -435,7 +345,7 @@ class MainViewController: UIViewController {
     }
 }
 
-private extension MainViewController {
+private extension ImageGeneratorViewController {
     // MARK: - ScrollView setting
     func configScrollView() {
         self.view.addSubview(entireScrollView)
@@ -454,8 +364,9 @@ private extension MainViewController {
     
     // MARK: - StackView setting
     func configStackView() {
-        self.entireStackView.addArrangedSubview(promptStackView)
-        self.entireStackView.addArrangedSubview(negativePromptStackView)
+        self.entireStackView.addArrangedSubview(positivePromptView)
+        self.entireStackView.addArrangedSubview(negativePromptView)
+        
         self.entireStackView.addArrangedSubview(imageQualityStackView)
         self.entireStackView.addArrangedSubview(imageCountStackView)
         self.entireStackView.addArrangedSubview(noiseRemoveStepsStackView)
@@ -465,8 +376,8 @@ private extension MainViewController {
         self.entireStackView.addArrangedSubview(noiseRemoveScaleByDecoderStackView)
         self.entireStackView.addArrangedSubview(generateButton)
 
-        configPromptStackView()
-        configNegativePromptStackView()
+        positivePromptView.textViewDelegate = self
+        negativePromptView.textViewDelegate = self
         
         configImageQualityStackView()
         configImageCountStackView()
@@ -485,42 +396,6 @@ private extension MainViewController {
             make.edges.equalTo(entireScrollView.snp.edges).inset(20)
             make.centerX.equalTo(entireScrollView.snp.centerX)
         }
-    }
-    
-    // MARK: - Prompt setting
-    func configPromptStackView() {
-        promptStackView.addArrangedSubview(promptLabelStackView)
-        promptStackView.addArrangedSubview(promptTextView)
-        
-        promptStackView.spacing = 10
-        
-        promptTextView.snp.makeConstraints { make in
-            make.height.equalTo(100)
-        }
-        
-        promptLabelStackView.addArrangedSubview(promptLabel)
-        promptLabelStackView.addArrangedSubview(UIView())
-        promptLabelStackView.addArrangedSubview(promptTextCountLabel)
-        
-        promptTextView.delegate = self
-    }
-    
-    // MARK: - Negative Prompt setting
-    func configNegativePromptStackView() {
-        negativePromptStackView.addArrangedSubview(negativePromptLabelStackView)
-        negativePromptStackView.addArrangedSubview(negativePromptTextView)
-        
-        negativePromptStackView.spacing = 10
-        
-        negativePromptTextView.snp.makeConstraints { make in
-            make.height.equalTo(100)
-        }
-        
-        negativePromptLabelStackView.addArrangedSubview(negativePromptLabel)
-        negativePromptLabelStackView.addArrangedSubview(UIView())
-        negativePromptLabelStackView.addArrangedSubview(negativePromptTextCountLabel)
-        
-        negativePromptTextView.delegate = self
     }
     
     // MARK: - Image Quality Setting
@@ -624,7 +499,7 @@ private extension MainViewController {
 }
 
 // MARK: - Obj Method
-private extension MainViewController {
+private extension ImageGeneratorViewController {
     // Stepper func
     @objc func imageCountStepperValueChanged(_ sender: UIStepper) {
         let value = Int(sender.value)
@@ -663,8 +538,8 @@ private extension MainViewController {
     }
     
     @objc func generateButtonTapped() {
-        let configuration = ImageConfiguration(prompt: promptTextView.text,
-                                               negetivePrompt: negativePromptTextView.text,
+        let configuration = ImageConfiguration(prompt: positivePromptView.promptText,
+                                               negetivePrompt: negativePromptView.promptText,
                                                imageQuality: Int(imageQualityCountLabel.text!)!,
                                                imageCount: Int(imageCountStpperCountLabel.text!)!,
                                                noiseRemoveSteps: Int(noiseRemoveStepsCountLabel.text!)!,
@@ -697,7 +572,7 @@ private extension MainViewController {
     }
 }
 
-extension MainViewController: UITextViewDelegate {
+extension ImageGeneratorViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         let currentText = textView.text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: text)
@@ -710,12 +585,12 @@ extension MainViewController: UITextViewDelegate {
         }
         
         if newText.count <= 256 {
-            if textView == promptTextView {
-                promptTextCountLabel.text = "\(newText.count) / 256"
+            if textView == positivePromptView.promptTextView {
+                positivePromptView.setPromptTextCountLabel("\(newText.count) / 256")
             }
-            
-            if textView == negativePromptTextView {
-                negativePromptTextCountLabel.text = "\(newText.count) / 256"
+
+            if textView == negativePromptView.promptTextView {
+                negativePromptView.setPromptTextCountLabel("\(newText.count) / 256")
             }
             
             return true

--- a/ImageMaker/ImageGenerationScene/View/ConfigurationSliderView.swift
+++ b/ImageMaker/ImageGenerationScene/View/ConfigurationSliderView.swift
@@ -1,0 +1,107 @@
+//
+//  ConfigurationSliderView.swift
+//  ImageMaker
+//
+//  Created by 이정민 on 2023/08/11.
+//
+
+import UIKit
+
+import SnapKit
+
+class ConfigurationSliderView: UIView {
+    private let SliderStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        
+        return stackView
+    }()
+    
+    private let ConfigurationLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        
+        return stackView
+    }()
+    
+    private let targetLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = Constant.textColor
+        label.font = .boldSystemFont(ofSize: 20)
+        
+        return label
+    }()
+    
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = Constant.textColor
+        
+        return label
+    }()
+    
+    private let configurationSlider: UISlider = {
+        let slider = UISlider()
+        
+        return slider
+    }()
+    
+    private let decimalPlaces: Int
+    
+    init(targetLabelText: String, sliderValue: Float, sliderMinValue: Float, sliderMaxValue: Float, decimalPlaces: Int) {
+        self.decimalPlaces = decimalPlaces
+        super.init(frame: .zero)
+        
+        configureView()
+        
+        targetLabel.text = targetLabelText
+        configurationSlider.minimumValue = sliderMinValue
+        configurationSlider.maximumValue = sliderMaxValue
+        configurationSlider.value = sliderValue
+        
+        setValueLabel(value: sliderValue)
+        
+        configurationSlider.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var sliderValue: Double {
+        Double(valueLabel.text!)!
+    }
+}
+
+private extension ConfigurationSliderView {
+    func configureView() {
+        SliderStackView.addArrangedSubview(ConfigurationLabelStackView)
+        SliderStackView.addArrangedSubview(configurationSlider)
+        
+        SliderStackView.spacing = 10
+        
+        ConfigurationLabelStackView.addArrangedSubview(targetLabel)
+        ConfigurationLabelStackView.addArrangedSubview(UIView())
+        ConfigurationLabelStackView.addArrangedSubview(valueLabel)
+        
+        addSubview(SliderStackView)
+        
+        SliderStackView.snp.makeConstraints { make in
+            make.edges.equalTo(self.snp.edges)
+        }
+    }
+    
+    func setValueLabel(value: Float) {
+        valueLabel.text = String(format: "%.\(self.decimalPlaces)f", value)
+    }
+}
+
+private extension ConfigurationSliderView {
+    @objc func sliderValueChanged(_ sender: UISlider) {
+        let value = sender.value
+        setValueLabel(value: value)
+    }
+}

--- a/ImageMaker/ImageGenerationScene/View/PromptView.swift
+++ b/ImageMaker/ImageGenerationScene/View/PromptView.swift
@@ -62,11 +62,11 @@ class PromptView: UIView {
         return textView
     }()
     
-    init(promptLabelString: String) {
+    init(promptLabelText: String) {
         super.init(frame: .zero)
         
-        promptLabel.text = promptLabelString
-        configView()
+        promptLabel.text = promptLabelText
+        configureView()
     }
     
     required init?(coder: NSCoder) {
@@ -83,7 +83,7 @@ class PromptView: UIView {
 }
 
 private extension PromptView {
-    func configView() {
+    func configureView() {
         promptStackView.addArrangedSubview(promptLabelStackView)
         promptStackView.addArrangedSubview(promptTextView)
         promptLabelStackView.addArrangedSubview(promptLabel)

--- a/ImageMaker/ImageGenerationScene/View/PromptView.swift
+++ b/ImageMaker/ImageGenerationScene/View/PromptView.swift
@@ -1,0 +1,104 @@
+//
+//  PromptView.swift
+//  ImageMaker
+//
+//  Created by 이정민 on 2023/08/11.
+//
+
+import UIKit
+
+import SnapKit
+
+class PromptView: UIView {
+    weak var textViewDelegate: UITextViewDelegate? {
+        didSet {
+            promptTextView.delegate = textViewDelegate
+        }
+    }
+    
+    private let promptStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        
+        return stackView
+    }()
+    
+    private let promptLabelStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        
+        return stackView
+    }()
+    
+    private let promptLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Prompt"
+        label.textColor = Constant.textColor
+        label.font = .boldSystemFont(ofSize: 20)
+        
+        return label
+    }()
+    
+    private let promptTextCountLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "0 / 256"
+        label.textColor = .lightGray
+        label.font = .preferredFont(forTextStyle: .caption2)
+        
+        return label
+    }()
+    
+    let promptTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.layer.cornerRadius = 8.0
+        textView.layer.borderWidth = 1.0
+        textView.layer.borderColor = UIColor.lightGray.cgColor
+        
+        return textView
+    }()
+    
+    init(promptLabelString: String) {
+        super.init(frame: .zero)
+        
+        promptLabel.text = promptLabelString
+        configView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var promptText: String {
+        promptTextView.text
+    }
+    
+    func setPromptTextCountLabel(_ text: String) {
+        self.promptTextCountLabel.text = text
+    }
+}
+
+private extension PromptView {
+    func configView() {
+        promptStackView.addArrangedSubview(promptLabelStackView)
+        promptStackView.addArrangedSubview(promptTextView)
+        promptLabelStackView.addArrangedSubview(promptLabel)
+        promptLabelStackView.addArrangedSubview(UIView())
+        promptLabelStackView.addArrangedSubview(promptTextCountLabel)
+        addSubview(promptStackView)
+        
+        promptStackView.spacing = 10
+        
+        promptTextView.snp.makeConstraints { make in
+            make.height.equalTo(100)
+        }
+        
+        promptStackView.snp.makeConstraints { make in
+            make.edges.equalTo(self.snp.edges)
+        }
+    }
+}

--- a/ImageMaker/SceneDelegate.swift
+++ b/ImageMaker/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = MainViewController(nibName: nil, bundle: nil)
+        window?.rootViewController = ImageGeneratorViewController(nibName: nil, bundle: nil)
         window?.makeKeyAndVisible()
         
     }


### PR DESCRIPTION
Closed #2 

### 구현내용
- 중복되는 Prompt 및 Slider들을 각각 PromptView, ConfigurationSliderView로 분리
- PromptView: PositivePrompt, NegativePrompt
- ConfigurationSliderView: NoiseRemoveStep, NoiseRemoveScale, NoiseRemoveStepByDecoder, NoiseRemoveScaleByDecoer

ViewController 코드 라인 수를 절반으로 경량화

### 필수체크
- [x] 정상적인 빌드